### PR TITLE
Integrate Twine custom indexer endpoints in blockscout frontend

### DIFF
--- a/configs/app/features/twine.ts
+++ b/configs/app/features/twine.ts
@@ -5,7 +5,7 @@ export const TWINE_CHAIN_MAPPING = {
   },
   '900': {
     name: 'Solana',
-    explorer_url: 'https://solana.io',
+    explorer_url: 'https://explorer.solana.com',
   },
 } as const;
 
@@ -15,10 +15,41 @@ export const isTwineChainId = (chainId: string): chainId is TwineChainId => {
   return chainId in TWINE_CHAIN_MAPPING;
 };
 
-export const getExplorerBaseUrl = (chainId: string) => {
+export const getExplorerTxUrl = (chainId: string, txHash: string) => {
+  // Solana explorer
   if (chainId === '900') {
-    return TWINE_CHAIN_MAPPING[chainId].explorer_url + '/tx';
+    return TWINE_CHAIN_MAPPING[chainId].explorer_url + '/tx/' + convertSolanaTxHashToBase58(txHash) + '?cluster=devnet';
   }
 
-  return TWINE_CHAIN_MAPPING[chainId as TwineChainId].explorer_url + '/tx';
+  // Ethereum explorer
+  // append 0x to the tx hash if it doesn't already have it
+  return TWINE_CHAIN_MAPPING[chainId as TwineChainId].explorer_url + '/tx/' + (txHash.startsWith('0x') ? txHash : '0x' + txHash);
+};
+
+export const convertSolanaTxHashToBase58 = (txHash: string) => {
+  // Convert hex string to Uint8Array
+  const bytes = new Uint8Array(txHash.match(/.{1,2}/g)?.map(byte => parseInt(byte, 16)) || []);
+
+  // Base58 alphabet
+  const ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+  // Convert to base58
+  let num = BigInt(0);
+  for (let i = 0; i < bytes.length; i++) {
+    num = num * BigInt(256) + BigInt(bytes[i]);
+  }
+
+  let base58 = '';
+  while (num > 0) {
+    const remainder = Number(num % BigInt(58));
+    base58 = ALPHABET[remainder] + base58;
+    num = num / BigInt(58);
+  }
+
+  // Add leading zeros
+  for (let i = 0; i < bytes.length && bytes[i] === 0; i++) {
+    base58 = '1' + base58;
+  }
+
+  return base58;
 };

--- a/configs/app/features/twine.ts
+++ b/configs/app/features/twine.ts
@@ -26,6 +26,16 @@ export const getExplorerTxUrl = (chainId: string, txHash: string) => {
   return TWINE_CHAIN_MAPPING[chainId as TwineChainId].explorer_url + '/tx/' + (txHash.startsWith('0x') ? txHash : '0x' + txHash);
 };
 
+export const getExplorerBlockUrl = (chainId: string, blockNumber: string) => {
+  // Solana explorer
+  if (chainId === '900') {
+    return TWINE_CHAIN_MAPPING[chainId].explorer_url + '/block/' + blockNumber + '?cluster=devnet';
+  }
+
+  // Ethereum explorer
+  return TWINE_CHAIN_MAPPING[chainId as TwineChainId].explorer_url + '/block/' + blockNumber;
+};
+
 export const convertSolanaTxHashToBase58 = (txHash: string) => {
   // Convert hex string to Uint8Array
   const bytes = new Uint8Array(txHash.match(/.{1,2}/g)?.map(byte => parseInt(byte, 16)) || []);

--- a/configs/app/features/twine.ts
+++ b/configs/app/features/twine.ts
@@ -3,6 +3,14 @@ export const TWINE_CHAIN_MAPPING = {
     name: 'Holesky',
     explorer_url: 'https://holesky.etherscan.io',
   },
+  '103': {
+    name: 'Solana',
+    explorer_url: 'https://explorer.solana.com',
+  },
+  '11155111': {
+    name: 'Sepolia',
+    explorer_url: 'https://sepolia.etherscan.io',
+  },
   '900': {
     name: 'Solana',
     explorer_url: 'https://explorer.solana.com',
@@ -17,8 +25,8 @@ export const isTwineChainId = (chainId: string): chainId is TwineChainId => {
 
 export const getExplorerTxUrl = (chainId: string, txHash: string) => {
   // Solana explorer
-  if (chainId === '900') {
-    return TWINE_CHAIN_MAPPING[chainId].explorer_url + '/tx/' + convertSolanaTxHashToBase58(txHash) + '?cluster=devnet';
+  if (chainId === '103' || chainId === '900') {
+    return TWINE_CHAIN_MAPPING[chainId].explorer_url + '/tx/' + (txHash) + '?cluster=devnet';
   }
 
   // Ethereum explorer
@@ -28,12 +36,23 @@ export const getExplorerTxUrl = (chainId: string, txHash: string) => {
 
 export const getExplorerBlockUrl = (chainId: string, blockNumber: string) => {
   // Solana explorer
-  if (chainId === '900') {
+  if (chainId === '103') {
     return TWINE_CHAIN_MAPPING[chainId].explorer_url + '/block/' + blockNumber + '?cluster=devnet';
   }
 
   // Ethereum explorer
   return TWINE_CHAIN_MAPPING[chainId as TwineChainId].explorer_url + '/block/' + blockNumber;
+};
+
+export const getExplorerAddressUrl = (chainId: string, address: string) => {
+  // Solana explorer
+  if (chainId === '103' || chainId === '900') {
+    return TWINE_CHAIN_MAPPING[chainId].explorer_url + '/address/' + address + '?cluster=devnet';
+  }
+
+  // Ethereum explorer
+  // append 0x to the address if it doesn't already have it
+  return TWINE_CHAIN_MAPPING[chainId as TwineChainId].explorer_url + '/address/' + (address.startsWith('0x') ? address : '0x' + address);
 };
 
 export const convertSolanaTxHashToBase58 = (txHash: string) => {

--- a/configs/app/features/twine.ts
+++ b/configs/app/features/twine.ts
@@ -14,3 +14,11 @@ export type TwineChainId = keyof typeof TWINE_CHAIN_MAPPING;
 export const isTwineChainId = (chainId: string): chainId is TwineChainId => {
   return chainId in TWINE_CHAIN_MAPPING;
 };
+
+export const getExplorerBaseUrl = (chainId: string) => {
+  if (chainId === '900') {
+    return TWINE_CHAIN_MAPPING[chainId].explorer_url + '/tx';
+  }
+
+  return TWINE_CHAIN_MAPPING[chainId as TwineChainId].explorer_url + '/tx';
+};

--- a/stubs/twineL2.ts
+++ b/stubs/twineL2.ts
@@ -1,7 +1,10 @@
-import type { TwineL2DepositsItem, TwineBatchesItem } from 'types/api/twineL2';
+import type { TwineL2DepositsItem, TwineBatchesItem, TwineL2WithdrawalsItem } from 'types/api/twineL2';
 
 export const TWINE_DEPOSITS_ITEM: TwineL2DepositsItem = {
-  tx_hash: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+  l1_tx_hash: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+  l2_tx_hash: '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+  slot_number: null,
+  l2_slot_number: 123,
   nonce: 26,
   chain_id: 17000,
   block_number: 671,
@@ -13,7 +16,7 @@ export const TWINE_DEPOSITS_ITEM: TwineL2DepositsItem = {
   created_at: '2025-02-04T08:00:12.123456Z',
 };
 
-export const TWINE_WITHDRAWAL_ITEM: TwineL2DepositsItem = {
+export const TWINE_WITHDRAWAL_ITEM: TwineL2WithdrawalsItem = {
   tx_hash: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
   nonce: 26,
   chain_id: 17000,

--- a/stubs/twineL2.ts
+++ b/stubs/twineL2.ts
@@ -53,7 +53,7 @@ export const TWINE_L2_TXN_BATCHES_ITEM: TwineBatchesItem = {
     },
     {
       id: 1,
-      chain_id: '900',
+      chain_id: '103',
       status: 'Executed on L1',
       l1_gas_price: '15000000000',
       l1_transaction_count: 100,

--- a/stubs/twineL2.ts
+++ b/stubs/twineL2.ts
@@ -17,16 +17,19 @@ export const TWINE_DEPOSITS_ITEM: TwineL2DepositsItem = {
 };
 
 export const TWINE_WITHDRAWAL_ITEM: TwineL2WithdrawalsItem = {
-  tx_hash: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
-  nonce: 26,
+  l1_tx_hash: '0x10b1bb8e4fd372eef2737342d9ea622e2ab7a3a9293cc80e46f4fc2c325cfef7',
+  l2_tx_hash: '0x0195cb6f6d5e44ad9a0a29005d9e6bc21e68ed5a167503f122e2b32173bceef3',
+  slot_number: null,
+  l2_slot_number: 3612114,
+  block_number: 3612114,
+  nonce: 6,
   chain_id: 17000,
-  block_number: 671,
   l1_token: '0x0000000000000000000000000000000000000000',
-  l2_token: '0xa8d297d643a11ce83b432e87eebce6bee0fd2bab',
-  from: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
-  to_twine_address: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
-  amount: '1500000000000000000',
-  created_at: '2025-02-04T08:00:12.123456Z',
+  l2_token: '0x3f22d27e4b8637cb430d7371d121dd37febe3c71',
+  from: '0xf9ccb674b4455f7c49cd119fde6c2208f0ed4976',
+  to_twine_address: '0xf9ccb674b4455f7c49cd119fde6c2208f0ed4976',
+  amount: '10000000000000000',
+  created_at: '2025-04-25T04:00:24.070256Z',
 };
 
 export const TWINE_L2_TXN_BATCHES_ITEM: TwineBatchesItem = {

--- a/types/api/block.ts
+++ b/types/api/block.ts
@@ -69,6 +69,12 @@ export interface Block {
     end_block: number | null;
     root_hash: string | null;
   };
+
+  // DA FIELDS
+  da?: {
+    celestia: CelestiaData;
+  };
+
   arbitrum?: ArbitrumBlockData;
   optimism?: OptimismBlockData;
   // CELO FIELDS
@@ -80,6 +86,12 @@ export interface Block {
   // ZILLIQA FIELDS
   zilliqa?: ZilliqaBlockData;
 }
+
+type CelestiaData = {
+  namespace: string;
+  commitment_hash: string;
+  height: number;
+};
 
 type ArbitrumBlockData = {
   batch_number: number;

--- a/types/api/twineL2.ts
+++ b/types/api/twineL2.ts
@@ -11,10 +11,13 @@ export const TWINE_L2_TX_BATCH_STATUSES = [
 export type TwineBatchStatus = typeof TWINE_L2_TX_BATCH_STATUSES[number];
 
 export type TwineL2DepositsItem = {
-  tx_hash: string;
+  l1_tx_hash: string;
+  l2_tx_hash: string;
+  slot_number: number | null;
+  l2_slot_number: number;
+  block_number: number;
   nonce: number;
   chain_id: number;
-  block_number: number;
   l1_token: string;
   l2_token: string;
   from: string;

--- a/types/api/twineL2.ts
+++ b/types/api/twineL2.ts
@@ -36,10 +36,13 @@ export type TwineL2DepositsResponse = {
 };
 
 export type TwineL2WithdrawalsItem = {
-  tx_hash: string;
+  l1_tx_hash: string;
+  l2_tx_hash: string;
+  slot_number: number | null;
+  l2_slot_number: number;
+  block_number: number;
   nonce: number;
   chain_id: number;
-  block_number: number;
   l1_token: string;
   l2_token: string;
   from: string;

--- a/ui/block/BlockDetails.tsx
+++ b/ui/block/BlockDetails.tsx
@@ -36,6 +36,7 @@ import LinkInternal from 'ui/shared/links/LinkInternal';
 import PrevNext from 'ui/shared/PrevNext';
 import RawDataSnippet from 'ui/shared/RawDataSnippet';
 import StatusTag from 'ui/shared/statusTag/StatusTag';
+import { TwineIndividualChainDetails } from 'ui/shared/TwineIndividualChainDetails';
 import Utilization from 'ui/shared/Utilization/Utilization';
 import VerificationSteps from 'ui/shared/verificationSteps/VerificationSteps';
 import ZkSyncL2TxnBatchHashesInfo from 'ui/txnBatches/zkSyncL2/ZkSyncL2TxnBatchHashesInfo';
@@ -828,6 +829,7 @@ const BlockDetails = ({ query }: Props) => {
           ) }
         </>
       ) }
+      { data.twine && <TwineIndividualChainDetails chainDetails={ data.twine.details }/> }
     </Grid>
   );
 };

--- a/ui/block/BlockDetails.tsx
+++ b/ui/block/BlockDetails.tsx
@@ -827,6 +827,44 @@ const BlockDetails = ({ query }: Props) => {
               ) }
             </>
           ) }
+
+          { data.da && (
+            <>
+              <DetailsInfoItemDivider/>
+              <DetailsInfoItem.Label
+                hint="Data Availability information for Celestia"
+              >
+                Data Availability
+              </DetailsInfoItem.Label>
+              <DetailsInfoItem.Value>
+                { data.da.celestia.commitment_hash ? (
+                  <Flex direction="column" gap={ 2 }>
+                    <Box>
+                      <Text fontWeight="medium">Commitment Hash:</Text>
+                      <Flex alignItems="center" gap={ 2 }>
+                        <HashStringShortenDynamic hash={ data.da.celestia.commitment_hash }/>
+                        <CopyToClipboard text={ data.da.celestia.commitment_hash }/>
+                      </Flex>
+                    </Box>
+                    { data.da.celestia.namespace && (
+                      <Box>
+                        <Text fontWeight="medium">Namespace:</Text>
+                        <Text>{ data.da.celestia.namespace }</Text>
+                      </Box>
+                    ) }
+                    { data.da.celestia.height && (
+                      <Box>
+                        <Text fontWeight="medium">Height:</Text>
+                        <Text>{ data.da.celestia.height }</Text>
+                      </Box>
+                    ) }
+                  </Flex>
+                ) : (
+                  <Text>Not committed to Celestia yet</Text>
+                ) }
+              </DetailsInfoItem.Value>
+            </>
+          ) }
         </>
       ) }
       { data.twine && <TwineIndividualChainDetails chainDetails={ data.twine.details }/> }

--- a/ui/deposits/twine/TwineDepositsListItem.tsx
+++ b/ui/deposits/twine/TwineDepositsListItem.tsx
@@ -3,10 +3,11 @@ import React from 'react';
 import type { TwineL2DepositsItem } from 'types/api/twineL2';
 
 import config from 'configs/app';
+import { isTwineChainId, TWINE_CHAIN_MAPPING } from 'configs/app/features/twine';
+import shortenString from 'lib/shortenString';
 import AddressEntity from 'ui/shared/entities/address/AddressEntity';
-import AddressEntityL1 from 'ui/shared/entities/address/AddressEntityL1';
-import BlockEntityL1 from 'ui/shared/entities/block/BlockEntityL1';
 import TxEntity from 'ui/shared/entities/tx/TxEntity';
+import TwineExternalLink from 'ui/shared/links/TwineExternalLink';
 import ListItemMobileGrid from 'ui/shared/ListItemMobile/ListItemMobileGrid';
 import TimeAgoWithTooltip from 'ui/shared/TimeAgoWithTooltip';
 
@@ -19,25 +20,53 @@ const TwineDepositsListItem = ({ item, isLoading }: Props) => {
     return null;
   }
 
+  const isSolana = isTwineChainId(String(item.chain_id)) && item.chain_id === 900;
+  const chainKey = String(item.chain_id) as keyof typeof TWINE_CHAIN_MAPPING;
+  const chainName = TWINE_CHAIN_MAPPING[chainKey]?.name || String(item.chain_id);
+
   return (
     <ListItemMobileGrid.Container>
+      <ListItemMobileGrid.Label isLoading={ isLoading }>
+        Chain
+      </ListItemMobileGrid.Label>
+      <ListItemMobileGrid.Value>
+        { chainName }
+      </ListItemMobileGrid.Value>
 
       <ListItemMobileGrid.Label isLoading={ isLoading }>Block number</ListItemMobileGrid.Label>
       <ListItemMobileGrid.Value>
-        <BlockEntityL1
-          number={ item.block_number }
-          isLoading={ isLoading }
-          fontSize="sm"
-          lineHeight={ 5 }
-          fontWeight={ 600 }
-        />
+        { !isSolana && item.block_number ? (
+          <TwineExternalLink href={ item.block_number } chainId={ String(item.chain_id) } type="block" isLoading={ isLoading }>
+            { item.block_number }
+          </TwineExternalLink>
+        ) : (
+          <span>-</span>
+        ) }
       </ListItemMobileGrid.Value>
 
-      <ListItemMobileGrid.Label isLoading={ isLoading }>Tx Hash</ListItemMobileGrid.Label>
+      <ListItemMobileGrid.Label isLoading={ isLoading }>Slot number</ListItemMobileGrid.Label>
+      <ListItemMobileGrid.Value>
+        { isSolana && item.slot_number ? (
+          <TwineExternalLink href={ item.slot_number } chainId={ String(item.chain_id) } type="slot" isLoading={ isLoading }>
+            { item.slot_number }
+          </TwineExternalLink>
+        ) : (
+          <span>-</span>
+        ) }
+      </ListItemMobileGrid.Value>
+
+      <ListItemMobileGrid.Label isLoading={ isLoading }>L1 Tx Hash</ListItemMobileGrid.Label>
+      <ListItemMobileGrid.Value>
+        <TwineExternalLink href={ item.l1_tx_hash } chainId={ String(item.chain_id) } type="tx" isLoading={ isLoading }>
+          { shortenString(item.l1_tx_hash, 8) }
+        </TwineExternalLink>
+      </ListItemMobileGrid.Value>
+
+      <ListItemMobileGrid.Label isLoading={ isLoading }>L2 Tx Hash</ListItemMobileGrid.Label>
       <ListItemMobileGrid.Value>
         <TxEntity
           isLoading={ isLoading }
-          hash={ item.tx_hash }
+          hash={ item.l2_tx_hash }
           fontSize="sm"
           lineHeight={ 5 }
           truncation="constant_long"
@@ -55,30 +84,24 @@ const TwineDepositsListItem = ({ item, isLoading }: Props) => {
 
       <ListItemMobileGrid.Label isLoading={ isLoading }>L1 Token Address</ListItemMobileGrid.Label>
       <ListItemMobileGrid.Value>
-        <AddressEntityL1
-          address={{ hash: item.l1_token, name: '', is_contract: false, is_verified: false, ens_domain_name: null, implementations: null }}
-          isLoading={ isLoading }
-          noCopy
-          truncation="constant"
-        />
+        <TwineExternalLink href={ item.l1_token } chainId={ String(item.chain_id) } type="tx" isLoading={ isLoading }>
+          { shortenString(item.l1_token, 8) }
+        </TwineExternalLink>
       </ListItemMobileGrid.Value>
       <ListItemMobileGrid.Label isLoading={ isLoading }>L2 Token Address</ListItemMobileGrid.Label>
       <ListItemMobileGrid.Value>
-        <AddressEntityL1
+        <AddressEntity
           address={{ hash: item.l2_token, name: '', is_contract: false, is_verified: false, ens_domain_name: null, implementations: null }}
           isLoading={ isLoading }
-          noCopy
           truncation="constant"
+          noCopy
         />
       </ListItemMobileGrid.Value>
       <ListItemMobileGrid.Label isLoading={ isLoading }>From</ListItemMobileGrid.Label>
       <ListItemMobileGrid.Value>
-        <AddressEntityL1
-          address={{ hash: item.from, name: '', is_contract: false, is_verified: false, ens_domain_name: null, implementations: null }}
-          isLoading={ isLoading }
-          noCopy
-          truncation="constant"
-        />
+        <TwineExternalLink href={ item.from } chainId={ String(item.chain_id) } type="tx" isLoading={ isLoading }>
+          { shortenString(item.from, 8) }
+        </TwineExternalLink>
       </ListItemMobileGrid.Value>
       <ListItemMobileGrid.Label isLoading={ isLoading }>To (Twine Address)</ListItemMobileGrid.Label>
       <ListItemMobileGrid.Value>
@@ -94,7 +117,6 @@ const TwineDepositsListItem = ({ item, isLoading }: Props) => {
       <ListItemMobileGrid.Value>
         { item.amount }
       </ListItemMobileGrid.Value>
-
     </ListItemMobileGrid.Container>
   );
 };

--- a/ui/deposits/twine/TwineDepositsListItem.tsx
+++ b/ui/deposits/twine/TwineDepositsListItem.tsx
@@ -84,7 +84,7 @@ const TwineDepositsListItem = ({ item, isLoading }: Props) => {
 
       <ListItemMobileGrid.Label isLoading={ isLoading }>L1 Token Address</ListItemMobileGrid.Label>
       <ListItemMobileGrid.Value>
-        <TwineExternalLink href={ item.l1_token } chainId={ String(item.chain_id) } type="tx" isLoading={ isLoading }>
+        <TwineExternalLink href={ item.l1_token } chainId={ String(item.chain_id) } type="address" isLoading={ isLoading }>
           { shortenString(item.l1_token, 8) }
         </TwineExternalLink>
       </ListItemMobileGrid.Value>
@@ -99,7 +99,7 @@ const TwineDepositsListItem = ({ item, isLoading }: Props) => {
       </ListItemMobileGrid.Value>
       <ListItemMobileGrid.Label isLoading={ isLoading }>From</ListItemMobileGrid.Label>
       <ListItemMobileGrid.Value>
-        <TwineExternalLink href={ item.from } chainId={ String(item.chain_id) } type="tx" isLoading={ isLoading }>
+        <TwineExternalLink href={ item.from } chainId={ String(item.chain_id) } type="address" isLoading={ isLoading }>
           { shortenString(item.from, 8) }
         </TwineExternalLink>
       </ListItemMobileGrid.Value>

--- a/ui/deposits/twine/TwineDepositsTable.tsx
+++ b/ui/deposits/twine/TwineDepositsTable.tsx
@@ -7,19 +7,22 @@ import { default as Thead } from 'ui/shared/TheadSticky';
 
 import TwineDepositsTableItem from './TwineDepositsTableItem';
 
- type Props = {
-   items: Array<TwineL2DepositsItem>;
-   top: number;
-   isLoading?: boolean;
- };
+type Props = {
+  items: Array<TwineL2DepositsItem>;
+  top: number;
+  isLoading?: boolean;
+};
 
 const TwineDepositsTable = ({ items, top, isLoading }: Props) => {
   return (
-    <Table style={{ tableLayout: 'auto' }} minW="950px">
+    <Table style={{ tableLayout: 'auto' }} minW="1100px">
       <Thead top={ top }>
         <Tr>
+          <Th>Chain</Th>
           <Th>Block No.</Th>
-          <Th>Txn hash</Th>
+          <Th>Slot No.</Th>
+          <Th>L1 Txn hash</Th>
+          <Th>L2 Txn hash</Th>
           <Th>Age</Th>
           <Th>L1 Token Address</Th>
           <Th>L2 Token Address</Th>
@@ -29,7 +32,7 @@ const TwineDepositsTable = ({ items, top, isLoading }: Props) => {
       </Thead>
       <Tbody>
         { items.map((item, index) => (
-          <TwineDepositsTableItem key={ item.tx_hash + (isLoading ? index : '') } item={ item } isLoading={ isLoading }/>
+          <TwineDepositsTableItem key={ item.l1_tx_hash + (isLoading ? index : '') } item={ item } isLoading={ isLoading }/>
         )) }
       </Tbody>
     </Table>

--- a/ui/deposits/twine/TwineDepositsTableItem.tsx
+++ b/ui/deposits/twine/TwineDepositsTableItem.tsx
@@ -20,7 +20,7 @@ const TwineDepositsTableItem = ({ item, isLoading }: Props) => {
     return null;
   }
 
-  const isSolana = isTwineChainId(String(item.chain_id)) && item.chain_id === 900;
+  const isSolana = isTwineChainId(String(item.chain_id)) && (item.chain_id === 900 || item.chain_id === 103);
   const chainKey = String(item.chain_id) as keyof typeof TWINE_CHAIN_MAPPING;
   const chainName = TWINE_CHAIN_MAPPING[chainKey]?.name || String(item.chain_id);
 
@@ -72,7 +72,7 @@ const TwineDepositsTableItem = ({ item, isLoading }: Props) => {
       </Td>
 
       <Td verticalAlign="middle">
-        <TwineExternalLink href={ item.l1_token } chainId={ String(item.chain_id) } type="tx" isLoading={ isLoading }>
+        <TwineExternalLink href={ item.l1_token } chainId={ String(item.chain_id) } type="address" isLoading={ isLoading }>
           { shortenString(item.l1_token, 8) }
         </TwineExternalLink>
       </Td>
@@ -85,7 +85,7 @@ const TwineDepositsTableItem = ({ item, isLoading }: Props) => {
         />
       </Td>
       <Td verticalAlign="middle">
-        <TwineExternalLink href={ item.from } chainId={ String(item.chain_id) } type="tx" isLoading={ isLoading }>
+        <TwineExternalLink href={ item.from } chainId={ String(item.chain_id) } type="address" isLoading={ isLoading }>
           { shortenString(item.from, 8) }
         </TwineExternalLink>
       </Td>

--- a/ui/deposits/twine/TwineDepositsTableItem.tsx
+++ b/ui/deposits/twine/TwineDepositsTableItem.tsx
@@ -1,41 +1,61 @@
-import { Td, Tr } from '@chakra-ui/react';
+import { Td, Tr, Badge } from '@chakra-ui/react';
 import React from 'react';
 
 import type { TwineL2DepositsItem } from 'types/api/twineL2';
 
 import config from 'configs/app';
+import { isTwineChainId, TWINE_CHAIN_MAPPING } from 'configs/app/features/twine';
+import shortenString from 'lib/shortenString';
 import AddressEntity from 'ui/shared/entities/address/AddressEntity';
-import AddressEntityL1 from 'ui/shared/entities/address/AddressEntityL1';
-import BlockEntityL1 from 'ui/shared/entities/block/BlockEntityL1';
 import TxEntity from 'ui/shared/entities/tx/TxEntity';
+import TwineExternalLink from 'ui/shared/links/TwineExternalLink';
 import TimeAgoWithTooltip from 'ui/shared/TimeAgoWithTooltip';
 
 const rollupFeature = config.features.rollup;
 
- type Props = { item: TwineL2DepositsItem; isLoading?: boolean };
+type Props = { item: TwineL2DepositsItem; isLoading?: boolean };
 
 const TwineDepositsTableItem = ({ item, isLoading }: Props) => {
-
   if (!rollupFeature.isEnabled || rollupFeature.type !== 'twine') {
     return null;
   }
 
+  const isSolana = isTwineChainId(String(item.chain_id)) && item.chain_id === 900;
+  const chainKey = String(item.chain_id) as keyof typeof TWINE_CHAIN_MAPPING;
+  const chainName = TWINE_CHAIN_MAPPING[chainKey]?.name || String(item.chain_id);
+
   return (
     <Tr>
       <Td verticalAlign="middle">
-        <BlockEntityL1
-          number={ item.block_number }
-          isLoading={ isLoading }
-          fontSize="sm"
-          lineHeight={ 5 }
-          fontWeight={ 600 }
-          noIcon
-        />
+        <Badge colorScheme={ isSolana ? 'purple' : 'blue' }>{ chainName }</Badge>
+      </Td>
+      <Td verticalAlign="middle">
+        { !isSolana && item.block_number ? (
+          <TwineExternalLink href={ item.block_number } chainId={ String(item.chain_id) } type="block" isLoading={ isLoading }>
+            { item.block_number }
+          </TwineExternalLink>
+        ) : (
+          <span>-</span>
+        ) }
+      </Td>
+      <Td verticalAlign="middle">
+        { isSolana && item.slot_number ? (
+          <TwineExternalLink href={ item.slot_number } chainId={ String(item.chain_id) } type="slot" isLoading={ isLoading }>
+            { item.slot_number }
+          </TwineExternalLink>
+        ) : (
+          <span>-</span>
+        ) }
+      </Td>
+      <Td verticalAlign="middle">
+        <TwineExternalLink href={ item.l1_tx_hash } chainId={ String(item.chain_id) } type="tx" isLoading={ isLoading }>
+          { shortenString(item.l1_tx_hash, 8) }
+        </TwineExternalLink>
       </Td>
       <Td verticalAlign="middle">
         <TxEntity
           isLoading={ isLoading }
-          hash={ item.tx_hash }
+          hash={ item.l2_tx_hash }
           fontSize="sm"
           lineHeight={ 5 }
           truncation="constant_long"
@@ -52,12 +72,9 @@ const TwineDepositsTableItem = ({ item, isLoading }: Props) => {
       </Td>
 
       <Td verticalAlign="middle">
-        <AddressEntityL1
-          address={{ hash: item.l1_token, name: '', is_contract: false, is_verified: false, ens_domain_name: null, implementations: null }}
-          isLoading={ isLoading }
-          truncation="constant"
-          noCopy
-        />
+        <TwineExternalLink href={ item.l1_token } chainId={ String(item.chain_id) } type="tx" isLoading={ isLoading }>
+          { shortenString(item.l1_token, 8) }
+        </TwineExternalLink>
       </Td>
       <Td verticalAlign="middle">
         <AddressEntity
@@ -68,12 +85,9 @@ const TwineDepositsTableItem = ({ item, isLoading }: Props) => {
         />
       </Td>
       <Td verticalAlign="middle">
-        <AddressEntityL1
-          address={{ hash: item.from, name: '', is_contract: false, is_verified: false, ens_domain_name: null, implementations: null }}
-          isLoading={ isLoading }
-          truncation="constant"
-          noCopy
-        />
+        <TwineExternalLink href={ item.from } chainId={ String(item.chain_id) } type="tx" isLoading={ isLoading }>
+          { shortenString(item.from, 8) }
+        </TwineExternalLink>
       </Td>
       <Td verticalAlign="middle">
         <AddressEntity
@@ -83,7 +97,6 @@ const TwineDepositsTableItem = ({ item, isLoading }: Props) => {
           noCopy
         />
       </Td>
-
     </Tr>
   );
 };

--- a/ui/pages/TwineL2Deposits.tsx
+++ b/ui/pages/TwineL2Deposits.tsx
@@ -34,7 +34,7 @@ const TwineL2Deposits = () => {
       <Show below="lg" ssr={ false }>
         { data.items.map(((item, index) => (
           <TwineDepositsListItem
-            key={ item.tx_hash + (isPlaceholderData ? index : '') }
+            key={ item.l2_tx_hash + (isPlaceholderData ? index : '') }
             isLoading={ isPlaceholderData }
             item={ item }
           />

--- a/ui/pages/TwineL2Withdrawals.tsx
+++ b/ui/pages/TwineL2Withdrawals.tsx
@@ -33,7 +33,7 @@ const TwineL2Withdrawals = () => {
       <Show below="lg" ssr={ false }>
         { data.items.map(((item, index) => (
           <TwineDepositsListItem
-            key={ item.tx_hash + (isPlaceholderData ? index : '') }
+            key={ item.l2_tx_hash + (isPlaceholderData ? index : '') }
             isLoading={ isPlaceholderData }
             item={ item }
           />

--- a/ui/shared/TwineIndividualChainDetails.tsx
+++ b/ui/shared/TwineIndividualChainDetails.tsx
@@ -4,7 +4,7 @@ import { Element } from 'react-scroll';
 
 import type { TwineBatchesItem } from 'types/api/twineL2';
 
-import { isTwineChainId, TWINE_CHAIN_MAPPING, convertSolanaTxHashToBase58 } from 'configs/app/features/twine';
+import { isTwineChainId, TWINE_CHAIN_MAPPING } from 'configs/app/features/twine';
 import * as DetailsInfoItem from 'ui/shared/DetailsInfoItem';
 
 import CopyToClipboard from './CopyToClipboard';
@@ -24,8 +24,8 @@ const truncateHash = (hash: string) => {
 
 const formatTxHash = (chainId: string, txHash: string) => {
 
-  if (chainId === '900') {
-    const base58Hash = convertSolanaTxHashToBase58(txHash);
+  if (chainId === '103' || chainId === '900') {
+    const base58Hash = (txHash);
     return truncateHash(base58Hash);
   }
   const formattedHash = txHash.startsWith('0x') ? txHash : `0x${ txHash }`;
@@ -33,9 +33,10 @@ const formatTxHash = (chainId: string, txHash: string) => {
 };
 
 const getClipBoardText = (chainId: string, txHash: string) => {
-  if (chainId === '900') {
-    return convertSolanaTxHashToBase58(txHash);
+  if (chainId === '103' || chainId === '900') {
+    return (txHash);
   }
+
   return txHash.startsWith('0x') ? txHash : `0x${ txHash }`;
 };
 

--- a/ui/shared/TwineIndividualChainDetails.tsx
+++ b/ui/shared/TwineIndividualChainDetails.tsx
@@ -4,7 +4,7 @@ import { Element } from 'react-scroll';
 
 import type { TwineBatchesItem } from 'types/api/twineL2';
 
-import { isTwineChainId, TWINE_CHAIN_MAPPING } from 'configs/app/features/twine';
+import { isTwineChainId, TWINE_CHAIN_MAPPING, convertSolanaTxHashToBase58 } from 'configs/app/features/twine';
 import * as DetailsInfoItem from 'ui/shared/DetailsInfoItem';
 
 import CopyToClipboard from './CopyToClipboard';
@@ -16,6 +16,28 @@ import TruncatedValue from './TruncatedValue';
 interface Props {
   chainDetails: TwineBatchesItem['details'];
 }
+
+const truncateHash = (hash: string) => {
+  if (hash.length <= 12) return hash;
+  return `${ hash.slice(0, 10) }...${ hash.slice(-10) }`;
+};
+
+const formatTxHash = (chainId: string, txHash: string) => {
+
+  if (chainId === '900') {
+    const base58Hash = convertSolanaTxHashToBase58(txHash);
+    return truncateHash(base58Hash);
+  }
+  const formattedHash = txHash.startsWith('0x') ? txHash : `0x${ txHash }`;
+  return truncateHash(formattedHash);
+};
+
+const getClipBoardText = (chainId: string, txHash: string) => {
+  if (chainId === '900') {
+    return convertSolanaTxHashToBase58(txHash);
+  }
+  return txHash.startsWith('0x') ? txHash : `0x${ txHash }`;
+};
 
 export const TwineIndividualChainDetails = ({ chainDetails }: Props) => {
   return (
@@ -70,15 +92,17 @@ export const TwineIndividualChainDetails = ({ chainDetails }: Props) => {
 
                 <DetailsInfoItem.Label>Commit transaction</DetailsInfoItem.Label>
                 <DetailsInfoItem.Value>
-                  <Flex alignItems="center" gap={ 3 }>
-                    <TwineExternalLink href={ detail.commit_transaction_hash } chainId={ detail.chain_id }>
-                      <TruncatedValue value={ detail.commit_transaction_hash }/>
-                    </TwineExternalLink>
-                    <CopyToClipboard text={ detail.commit_transaction_hash }/>
+                  <Flex gap={ 3 } direction="column" >
+                    <div className="flex gap-3 items-center justify-center">
+                      <TwineExternalLink href={ detail.commit_transaction_hash } chainId={ detail.chain_id }>
+                        <TruncatedValue value={ formatTxHash(detail.chain_id, detail.commit_transaction_hash) }/>
+                      </TwineExternalLink>
+                      <CopyToClipboard text={ getClipBoardText(detail.chain_id, detail.commit_transaction_hash) }/>
+                    </div>
                     { detail.commit_transaction_timestamp && (
-                      <Text as="span" variant="secondary" whiteSpace="nowrap">
+                      <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
                         <DetailsTimestamp timestamp={ detail.commit_transaction_timestamp }/>
-                      </Text>
+                      </div>
                     ) }
                   </Flex>
                 </DetailsInfoItem.Value>
@@ -87,15 +111,17 @@ export const TwineIndividualChainDetails = ({ chainDetails }: Props) => {
                   <>
                     <DetailsInfoItem.Label>Prove transaction</DetailsInfoItem.Label>
                     <DetailsInfoItem.Value>
-                      <Flex alignItems="center" gap={ 3 }>
-                        <TwineExternalLink href={ detail.prove_transaction_hash } chainId={ detail.chain_id }>
-                          <TruncatedValue value={ detail.prove_transaction_hash }/>
-                        </TwineExternalLink>
-                        <CopyToClipboard text={ detail.prove_transaction_hash }/>
+                      <Flex gap={ 3 } direction="column" >
+                        <div className="flex gap-3 items-center justify-center">
+                          <TwineExternalLink href={ detail.prove_transaction_hash } chainId={ detail.chain_id }>
+                            <TruncatedValue value={ formatTxHash(detail.chain_id, detail.prove_transaction_hash) }/>
+                          </TwineExternalLink>
+                          <CopyToClipboard text={ getClipBoardText(detail.chain_id, detail.prove_transaction_hash) }/>
+                        </div>
                         { detail.prove_transaction_timestamp && (
-                          <Text as="span" variant="secondary" whiteSpace="nowrap">
+                          <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
                             <DetailsTimestamp timestamp={ detail.prove_transaction_timestamp }/>
-                          </Text>
+                          </div>
                         ) }
                       </Flex>
                     </DetailsInfoItem.Value>
@@ -104,15 +130,17 @@ export const TwineIndividualChainDetails = ({ chainDetails }: Props) => {
 
                 <DetailsInfoItem.Label>Execute transaction</DetailsInfoItem.Label>
                 <DetailsInfoItem.Value>
-                  <Flex alignItems="center" gap={ 3 }>
-                    <TwineExternalLink href={ detail.execute_transaction_hash } chainId={ detail.chain_id }>
-                      <TruncatedValue value={ detail.execute_transaction_hash }/>
-                    </TwineExternalLink>
-                    <CopyToClipboard text={ detail.execute_transaction_hash }/>
+                  <Flex gap={ 3 } direction="column" >
+                    <div className="flex gap-3 items-center justify-center">
+                      <TwineExternalLink href={ detail.execute_transaction_hash } chainId={ detail.chain_id }>
+                        <TruncatedValue value={ formatTxHash(detail.chain_id, detail.execute_transaction_hash) }/>
+                      </TwineExternalLink>
+                      <CopyToClipboard text={ getClipBoardText(detail.chain_id, detail.execute_transaction_hash) }/>
+                    </div>
                     { detail.execute_transaction_timestamp && (
-                      <Text as="span" variant="secondary" whiteSpace="nowrap">
+                      <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
                         <DetailsTimestamp timestamp={ detail.execute_transaction_timestamp }/>
-                      </Text>
+                      </div>
                     ) }
                   </Flex>
                 </DetailsInfoItem.Value>

--- a/ui/shared/TwineIndividualChainDetails.tsx
+++ b/ui/shared/TwineIndividualChainDetails.tsx
@@ -1,0 +1,126 @@
+import { Grid, GridItem, Text, Flex, Tag } from '@chakra-ui/react';
+import React from 'react';
+import { Element } from 'react-scroll';
+
+import type { TwineBatchesItem } from 'types/api/twineL2';
+
+import { isTwineChainId, TWINE_CHAIN_MAPPING } from 'configs/app/features/twine';
+import * as DetailsInfoItem from 'ui/shared/DetailsInfoItem';
+
+import CopyToClipboard from './CopyToClipboard';
+import DetailsInfoItemDivider from './DetailsInfoItemDivider';
+import DetailsTimestamp from './DetailsTimestamp';
+import TwineExternalLink from './links/TwineExternalLink';
+import TruncatedValue from './TruncatedValue';
+
+interface Props {
+  chainDetails: TwineBatchesItem['details'];
+}
+
+export const TwineIndividualChainDetails = ({ chainDetails }: Props) => {
+  return (
+    <GridItem colSpan={{ base: undefined, lg: 2 }}>
+      <Element name="TwineL2TxnBatchDetails__cutLink"/>
+      { chainDetails.map((detail, index) => {
+        const chainName = isTwineChainId(detail.chain_id) ? TWINE_CHAIN_MAPPING[detail.chain_id].name : `Chain ${ detail.chain_id }`;
+        return (
+          <React.Fragment key={ index }>
+            <Grid
+              mt={ index === 0 ? 6 : 8 }
+              pb={ 6 }
+              borderBottom={ index < chainDetails.length - 1 ? '1px solid' : 'none' }
+              borderColor="divider"
+            >
+              <GridItem colSpan={ 2 } mb={ 4 }>
+                <Text fontSize="lg" fontWeight="500">{ chainName } Details</Text>
+              </GridItem>
+
+              <Grid
+                columnGap={ 8 }
+                rowGap={ 3 }
+                templateColumns={{ base: 'minmax(0, 1fr)', lg: 'minmax(min-content, 200px) minmax(0, 1fr)' }}
+              >
+                <DetailsInfoItem.Label>Chain ID</DetailsInfoItem.Label>
+                <DetailsInfoItem.Value>{ detail.chain_id }</DetailsInfoItem.Value>
+
+                <DetailsInfoItem.Label>Status</DetailsInfoItem.Label>
+                <DetailsInfoItem.Value>
+                  <Tag
+                    size="sm"
+                    variant="solid"
+                    colorScheme={ detail.status === 'Executed on L1' ? 'green' : 'blue' }
+                  >
+                    { detail.status }
+                  </Tag>
+                </DetailsInfoItem.Value>
+
+                <DetailsInfoItem.Label>Transaction counts</DetailsInfoItem.Label>
+                <DetailsInfoItem.Value>
+                  <Text as="span" mr={ 4 }>L1: { detail.l1_transaction_count }</Text>
+                  <Text as="span">L2: { detail.l2_transaction_count }</Text>
+                </DetailsInfoItem.Value>
+
+                <DetailsInfoItem.Label>Gas prices</DetailsInfoItem.Label>
+                <DetailsInfoItem.Value>
+                  <Text as="span" mr={ 4 }>L1: { detail.l1_gas_price }</Text>
+                  <Text as="span">L2: { detail.l2_fair_gas_price }</Text>
+                </DetailsInfoItem.Value>
+
+                <DetailsInfoItemDivider/>
+
+                <DetailsInfoItem.Label>Commit transaction</DetailsInfoItem.Label>
+                <DetailsInfoItem.Value>
+                  <Flex alignItems="center" gap={ 3 }>
+                    <TwineExternalLink href={ detail.commit_transaction_hash } chainId={ detail.chain_id }>
+                      <TruncatedValue value={ detail.commit_transaction_hash }/>
+                    </TwineExternalLink>
+                    <CopyToClipboard text={ detail.commit_transaction_hash }/>
+                    { detail.commit_transaction_timestamp && (
+                      <Text as="span" variant="secondary" whiteSpace="nowrap">
+                        <DetailsTimestamp timestamp={ detail.commit_transaction_timestamp }/>
+                      </Text>
+                    ) }
+                  </Flex>
+                </DetailsInfoItem.Value>
+
+                { detail.prove_transaction_hash && (
+                  <>
+                    <DetailsInfoItem.Label>Prove transaction</DetailsInfoItem.Label>
+                    <DetailsInfoItem.Value>
+                      <Flex alignItems="center" gap={ 3 }>
+                        <TwineExternalLink href={ detail.prove_transaction_hash } chainId={ detail.chain_id }>
+                          <TruncatedValue value={ detail.prove_transaction_hash }/>
+                        </TwineExternalLink>
+                        <CopyToClipboard text={ detail.prove_transaction_hash }/>
+                        { detail.prove_transaction_timestamp && (
+                          <Text as="span" variant="secondary" whiteSpace="nowrap">
+                            <DetailsTimestamp timestamp={ detail.prove_transaction_timestamp }/>
+                          </Text>
+                        ) }
+                      </Flex>
+                    </DetailsInfoItem.Value>
+                  </>
+                ) }
+
+                <DetailsInfoItem.Label>Execute transaction</DetailsInfoItem.Label>
+                <DetailsInfoItem.Value>
+                  <Flex alignItems="center" gap={ 3 }>
+                    <TwineExternalLink href={ detail.execute_transaction_hash } chainId={ detail.chain_id }>
+                      <TruncatedValue value={ detail.execute_transaction_hash }/>
+                    </TwineExternalLink>
+                    <CopyToClipboard text={ detail.execute_transaction_hash }/>
+                    { detail.execute_transaction_timestamp && (
+                      <Text as="span" variant="secondary" whiteSpace="nowrap">
+                        <DetailsTimestamp timestamp={ detail.execute_transaction_timestamp }/>
+                      </Text>
+                    ) }
+                  </Flex>
+                </DetailsInfoItem.Value>
+              </Grid>
+            </Grid>
+          </React.Fragment>
+        );
+      }) }
+    </GridItem>
+  );
+};

--- a/ui/shared/links/TwineExternalLink.tsx
+++ b/ui/shared/links/TwineExternalLink.tsx
@@ -2,7 +2,7 @@ import type { LinkProps } from '@chakra-ui/react';
 import { Link, chakra, Box } from '@chakra-ui/react';
 import React from 'react';
 
-import { getExplorerBlockUrl, getExplorerTxUrl } from 'configs/app/features/twine';
+import { getExplorerBlockUrl, getExplorerTxUrl, getExplorerAddressUrl } from 'configs/app/features/twine';
 import Skeleton from 'ui/shared/chakra/Skeleton';
 import IconSvg from 'ui/shared/IconSvg';
 
@@ -18,7 +18,7 @@ interface Props {
   iconColor?: LinkProps['color'];
   onClick?: LinkProps['onClick'];
   chainId: string;
-  type?: 'tx' | 'block';
+  type?: 'tx' | 'block' | 'address';
 }
 
 const TwineExternalLink = ({ href, children, className, isLoading, variant, iconColor, onClick, chainId, type = 'tx' }: Props) => {
@@ -47,7 +47,18 @@ const TwineExternalLink = ({ href, children, className, isLoading, variant, icon
     );
   }
 
-  const externalUrl = type === 'tx' ? getExplorerTxUrl(chainId, href) : getExplorerBlockUrl(chainId, href);
+  const externalUrl = (() => {
+    switch (type) {
+      case 'tx':
+        return getExplorerTxUrl(chainId, href);
+      case 'block':
+        return getExplorerBlockUrl(chainId, href);
+      case 'address':
+        return getExplorerAddressUrl(chainId, href);
+      default:
+        return getExplorerTxUrl(chainId, href);
+    }
+  })();
 
   return (
     <Link className={ className } { ...styleProps } target="_blank" href={ externalUrl } onClick={ onClick }>

--- a/ui/shared/links/TwineExternalLink.tsx
+++ b/ui/shared/links/TwineExternalLink.tsx
@@ -1,0 +1,59 @@
+import type { LinkProps } from '@chakra-ui/react';
+import { Link, chakra, Box } from '@chakra-ui/react';
+import React from 'react';
+
+import { getExplorerBaseUrl } from 'configs/app/features/twine';
+import Skeleton from 'ui/shared/chakra/Skeleton';
+import IconSvg from 'ui/shared/IconSvg';
+
+import type { Variants } from './useLinkStyles';
+import { useLinkStyles } from './useLinkStyles';
+
+interface Props {
+  href: string;
+  className?: string;
+  children: React.ReactNode;
+  isLoading?: boolean;
+  variant?: Variants;
+  iconColor?: LinkProps['color'];
+  onClick?: LinkProps['onClick'];
+  chainId: string;
+}
+
+const TwineExternalLink = ({ href, children, className, isLoading, variant, iconColor, onClick, chainId }: Props) => {
+  const commonProps = {
+    display: 'inline-block',
+    alignItems: 'center',
+  };
+
+  const styleProps = useLinkStyles(commonProps, variant);
+
+  if (isLoading) {
+    if (variant === 'subtle') {
+      return (
+        <Skeleton className={ className } { ...styleProps } bgColor="inherit">
+          { children }
+          <Box boxSize={ 3 } display="inline-block"/>
+        </Skeleton>
+      );
+    }
+
+    return (
+      <Box className={ className } { ...styleProps }>
+        { children }
+        <Skeleton boxSize={ 3 } verticalAlign="middle" display="inline-block"/>
+      </Box>
+    );
+  }
+
+  const explorerBaseUrl = getExplorerBaseUrl(chainId);
+
+  return (
+    <Link className={ className } { ...styleProps } target="_blank" href={ `${ explorerBaseUrl }/${ href }` } onClick={ onClick }>
+      { children }
+      <IconSvg name="link_external" boxSize={ 3 } verticalAlign="middle" color={ iconColor ?? 'icon_link_external' } flexShrink={ 0 }/>
+    </Link>
+  );
+};
+
+export default React.memo(chakra(TwineExternalLink));

--- a/ui/shared/links/TwineExternalLink.tsx
+++ b/ui/shared/links/TwineExternalLink.tsx
@@ -2,7 +2,7 @@ import type { LinkProps } from '@chakra-ui/react';
 import { Link, chakra, Box } from '@chakra-ui/react';
 import React from 'react';
 
-import { getExplorerTxUrl } from 'configs/app/features/twine';
+import { getExplorerBlockUrl, getExplorerTxUrl } from 'configs/app/features/twine';
 import Skeleton from 'ui/shared/chakra/Skeleton';
 import IconSvg from 'ui/shared/IconSvg';
 
@@ -18,9 +18,10 @@ interface Props {
   iconColor?: LinkProps['color'];
   onClick?: LinkProps['onClick'];
   chainId: string;
+  type?: 'tx' | 'block';
 }
 
-const TwineExternalLink = ({ href, children, className, isLoading, variant, iconColor, onClick, chainId }: Props) => {
+const TwineExternalLink = ({ href, children, className, isLoading, variant, iconColor, onClick, chainId, type = 'tx' }: Props) => {
   const commonProps = {
     display: 'inline-block',
     alignItems: 'center',
@@ -46,10 +47,10 @@ const TwineExternalLink = ({ href, children, className, isLoading, variant, icon
     );
   }
 
-  const explorerTxUrl = getExplorerTxUrl(chainId, href);
+  const externalUrl = type === 'tx' ? getExplorerTxUrl(chainId, href) : getExplorerBlockUrl(chainId, href);
 
   return (
-    <Link className={ className } { ...styleProps } target="_blank" href={ explorerTxUrl } onClick={ onClick }>
+    <Link className={ className } { ...styleProps } target="_blank" href={ externalUrl } onClick={ onClick }>
       { children }
       <IconSvg name="link_external" boxSize={ 3 } verticalAlign="middle" color={ iconColor ?? 'icon_link_external' } flexShrink={ 0 }/>
     </Link>

--- a/ui/shared/links/TwineExternalLink.tsx
+++ b/ui/shared/links/TwineExternalLink.tsx
@@ -2,7 +2,7 @@ import type { LinkProps } from '@chakra-ui/react';
 import { Link, chakra, Box } from '@chakra-ui/react';
 import React from 'react';
 
-import { getExplorerBaseUrl } from 'configs/app/features/twine';
+import { getExplorerTxUrl } from 'configs/app/features/twine';
 import Skeleton from 'ui/shared/chakra/Skeleton';
 import IconSvg from 'ui/shared/IconSvg';
 
@@ -46,10 +46,10 @@ const TwineExternalLink = ({ href, children, className, isLoading, variant, icon
     );
   }
 
-  const explorerBaseUrl = getExplorerBaseUrl(chainId);
+  const explorerTxUrl = getExplorerTxUrl(chainId, href);
 
   return (
-    <Link className={ className } { ...styleProps } target="_blank" href={ `${ explorerBaseUrl }/${ href }` } onClick={ onClick }>
+    <Link className={ className } { ...styleProps } target="_blank" href={ explorerTxUrl } onClick={ onClick }>
       { children }
       <IconSvg name="link_external" boxSize={ 3 } verticalAlign="middle" color={ iconColor ?? 'icon_link_external' } flexShrink={ 0 }/>
     </Link>

--- a/ui/txnBatches/twineL2/TwineL2TxnBatchDetails.tsx
+++ b/ui/txnBatches/twineL2/TwineL2TxnBatchDetails.tsx
@@ -1,8 +1,7 @@
-import { Grid, GridItem, Text, Flex, Tag, TagLabel } from '@chakra-ui/react';
+import { Grid, Flex, Tag, TagLabel } from '@chakra-ui/react';
 import type { UseQueryResult } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
 import React from 'react';
-import { Element } from 'react-scroll';
 
 import type { TwineBatchesItem } from 'types/api/twineL2';
 
@@ -21,6 +20,7 @@ import DetailsTimestamp from 'ui/shared/DetailsTimestamp';
 import LinkInternal from 'ui/shared/links/LinkInternal';
 import PrevNext from 'ui/shared/PrevNext';
 import TruncatedValue from 'ui/shared/TruncatedValue';
+import { TwineIndividualChainDetails } from 'ui/shared/TwineIndividualChainDetails';
 
 interface Props {
   query: UseQueryResult<TwineBatchesItem, ResourceError>;
@@ -165,103 +165,7 @@ const TwineL2TxnBatchDetails = ({ query }: Props) => {
         <CopyToClipboard text={ data.root_hash }/>
       </DetailsInfoItem.Value>
 
-      <GridItem colSpan={{ base: undefined, lg: 2 }}>
-        <Element name="TwineL2TxnBatchDetails__cutLink"/>
-        { data.details.map((detail, index) => {
-          const chainName = isTwineChainId(detail.chain_id) ? TWINE_CHAIN_MAPPING[detail.chain_id].name : `Chain ${ detail.chain_id }`;
-          return (
-            <React.Fragment key={ index }>
-              <Grid
-                mt={ index === 0 ? 6 : 8 }
-                pb={ 6 }
-                borderBottom={ index < data.details.length - 1 ? '1px solid' : 'none' }
-                borderColor="divider"
-              >
-                <GridItem colSpan={ 2 } mb={ 4 }>
-                  <Text fontSize="lg" fontWeight="500">{ chainName } Details</Text>
-                </GridItem>
-
-                <Grid
-                  columnGap={ 8 }
-                  rowGap={ 3 }
-                  templateColumns={{ base: 'minmax(0, 1fr)', lg: 'minmax(min-content, 200px) minmax(0, 1fr)' }}
-                >
-                  <DetailsInfoItem.Label>Chain ID</DetailsInfoItem.Label>
-                  <DetailsInfoItem.Value>{ detail.chain_id }</DetailsInfoItem.Value>
-
-                  <DetailsInfoItem.Label>Status</DetailsInfoItem.Label>
-                  <DetailsInfoItem.Value>
-                    <Tag
-                      size="sm"
-                      variant="solid"
-                      colorScheme={ detail.status === 'Executed on L1' ? 'green' : 'blue' }
-                    >
-                      { detail.status }
-                    </Tag>
-                  </DetailsInfoItem.Value>
-
-                  <DetailsInfoItem.Label>Transaction counts</DetailsInfoItem.Label>
-                  <DetailsInfoItem.Value>
-                    <Text as="span" mr={ 4 }>L1: { detail.l1_transaction_count }</Text>
-                    <Text as="span">L2: { detail.l2_transaction_count }</Text>
-                  </DetailsInfoItem.Value>
-
-                  <DetailsInfoItem.Label>Gas prices</DetailsInfoItem.Label>
-                  <DetailsInfoItem.Value>
-                    <Text as="span" mr={ 4 }>L1: { detail.l1_gas_price }</Text>
-                    <Text as="span">L2: { detail.l2_fair_gas_price }</Text>
-                  </DetailsInfoItem.Value>
-
-                  <DetailsInfoItemDivider/>
-
-                  <DetailsInfoItem.Label>Commit transaction</DetailsInfoItem.Label>
-                  <DetailsInfoItem.Value>
-                    <Flex alignItems="center" gap={ 3 }>
-                      <TruncatedValue value={ detail.commit_transaction_hash }/>
-                      <CopyToClipboard text={ detail.commit_transaction_hash }/>
-                      { detail.commit_transaction_timestamp && (
-                        <Text as="span" variant="secondary" whiteSpace="nowrap">
-                          <DetailsTimestamp timestamp={ detail.commit_transaction_timestamp }/>
-                        </Text>
-                      ) }
-                    </Flex>
-                  </DetailsInfoItem.Value>
-
-                  { detail.prove_transaction_hash && (
-                    <>
-                      <DetailsInfoItem.Label>Prove transaction</DetailsInfoItem.Label>
-                      <DetailsInfoItem.Value>
-                        <Flex alignItems="center" gap={ 3 }>
-                          <TruncatedValue value={ detail.prove_transaction_hash }/>
-                          <CopyToClipboard text={ detail.prove_transaction_hash }/>
-                          { detail.prove_transaction_timestamp && (
-                            <Text as="span" variant="secondary" whiteSpace="nowrap">
-                              <DetailsTimestamp timestamp={ detail.prove_transaction_timestamp }/>
-                            </Text>
-                          ) }
-                        </Flex>
-                      </DetailsInfoItem.Value>
-                    </>
-                  ) }
-
-                  <DetailsInfoItem.Label>Execute transaction</DetailsInfoItem.Label>
-                  <DetailsInfoItem.Value>
-                    <Flex alignItems="center" gap={ 3 }>
-                      <TruncatedValue value={ detail.execute_transaction_hash }/>
-                      <CopyToClipboard text={ detail.execute_transaction_hash }/>
-                      { detail.execute_transaction_timestamp && (
-                        <Text as="span" variant="secondary" whiteSpace="nowrap">
-                          <DetailsTimestamp timestamp={ detail.execute_transaction_timestamp }/>
-                        </Text>
-                      ) }
-                    </Flex>
-                  </DetailsInfoItem.Value>
-                </Grid>
-              </Grid>
-            </React.Fragment>
-          );
-        }) }
-      </GridItem>
+      <TwineIndividualChainDetails chainDetails={ data.details }/>
     </Grid>
   );
 };

--- a/ui/withdrawals/twineL2/TwineL2WithdrawalsListItem.tsx
+++ b/ui/withdrawals/twineL2/TwineL2WithdrawalsListItem.tsx
@@ -3,10 +3,10 @@ import React from 'react';
 import type { TwineL2WithdrawalsItem } from 'types/api/twineL2';
 
 import config from 'configs/app';
+import { isTwineChainId, TWINE_CHAIN_MAPPING } from 'configs/app/features/twine';
+import shortenString from 'lib/shortenString';
 import AddressEntity from 'ui/shared/entities/address/AddressEntity';
-import AddressEntityL1 from 'ui/shared/entities/address/AddressEntityL1';
-import BlockEntityL1 from 'ui/shared/entities/block/BlockEntityL1';
-import TxEntity from 'ui/shared/entities/tx/TxEntity';
+import TwineExternalLink from 'ui/shared/links/TwineExternalLink';
 import ListItemMobileGrid from 'ui/shared/ListItemMobile/ListItemMobileGrid';
 import TimeAgoWithTooltip from 'ui/shared/TimeAgoWithTooltip';
 
@@ -19,29 +19,53 @@ const TwineWithdrawalsListItem = ({ item, isLoading }: Props) => {
     return null;
   }
 
+  const isSolana = isTwineChainId(String(item.chain_id)) && item.chain_id === 900;
+  const chainKey = String(item.chain_id) as keyof typeof TWINE_CHAIN_MAPPING;
+  const chainName = TWINE_CHAIN_MAPPING[chainKey]?.name || String(item.chain_id);
+
   return (
     <ListItemMobileGrid.Container>
+      <ListItemMobileGrid.Label isLoading={ isLoading }>
+        Chain
+      </ListItemMobileGrid.Label>
+      <ListItemMobileGrid.Value>
+        { chainName }
+      </ListItemMobileGrid.Value>
 
       <ListItemMobileGrid.Label isLoading={ isLoading }>Block number</ListItemMobileGrid.Label>
       <ListItemMobileGrid.Value>
-        <BlockEntityL1
-          number={ item.block_number }
-          isLoading={ isLoading }
-          fontSize="sm"
-          lineHeight={ 5 }
-          fontWeight={ 600 }
-        />
+        { !isSolana && item.block_number ? (
+          <TwineExternalLink href={ item.block_number } chainId={ String(item.chain_id) } type="block" isLoading={ isLoading }>
+            { item.block_number }
+          </TwineExternalLink>
+        ) : (
+          <span>-</span>
+        ) }
       </ListItemMobileGrid.Value>
 
-      <ListItemMobileGrid.Label isLoading={ isLoading }>Tx Hash</ListItemMobileGrid.Label>
+      <ListItemMobileGrid.Label isLoading={ isLoading }>Slot number</ListItemMobileGrid.Label>
       <ListItemMobileGrid.Value>
-        <TxEntity
-          isLoading={ isLoading }
-          hash={ item.tx_hash }
-          fontSize="sm"
-          lineHeight={ 5 }
-          truncation="constant_long"
-        />
+        { isSolana && item.slot_number ? (
+          <TwineExternalLink href={ item.slot_number } chainId={ String(item.chain_id) } type="slot" isLoading={ isLoading }>
+            { item.slot_number }
+          </TwineExternalLink>
+        ) : (
+          <span>-</span>
+        ) }
+      </ListItemMobileGrid.Value>
+
+      <ListItemMobileGrid.Label isLoading={ isLoading }>L1 Tx Hash</ListItemMobileGrid.Label>
+      <ListItemMobileGrid.Value>
+        <TwineExternalLink href={ item.l1_tx_hash } chainId={ String(item.chain_id) } type="tx" isLoading={ isLoading }>
+          { shortenString(item.l1_tx_hash, 8) }
+        </TwineExternalLink>
+      </ListItemMobileGrid.Value>
+
+      <ListItemMobileGrid.Label isLoading={ isLoading }>L2 Tx Hash</ListItemMobileGrid.Label>
+      <ListItemMobileGrid.Value>
+        <TwineExternalLink href={ item.l2_tx_hash } chainId={ String(item.chain_id) } type="tx" isLoading={ isLoading }>
+          { shortenString(item.l2_tx_hash, 8) }
+        </TwineExternalLink>
       </ListItemMobileGrid.Value>
 
       <ListItemMobileGrid.Label isLoading={ isLoading }>Age</ListItemMobileGrid.Label>
@@ -55,30 +79,24 @@ const TwineWithdrawalsListItem = ({ item, isLoading }: Props) => {
 
       <ListItemMobileGrid.Label isLoading={ isLoading }>L1 Token Address</ListItemMobileGrid.Label>
       <ListItemMobileGrid.Value>
-        <AddressEntityL1
-          address={{ hash: item.l1_token, name: '', is_contract: false, is_verified: false, ens_domain_name: null, implementations: null }}
-          isLoading={ isLoading }
-          noCopy
-          truncation="constant"
-        />
+        <TwineExternalLink href={ item.l1_token } chainId={ String(item.chain_id) } type="tx" isLoading={ isLoading }>
+          { shortenString(item.l1_token, 8) }
+        </TwineExternalLink>
       </ListItemMobileGrid.Value>
       <ListItemMobileGrid.Label isLoading={ isLoading }>L2 Token Address</ListItemMobileGrid.Label>
       <ListItemMobileGrid.Value>
-        <AddressEntityL1
+        <AddressEntity
           address={{ hash: item.l2_token, name: '', is_contract: false, is_verified: false, ens_domain_name: null, implementations: null }}
           isLoading={ isLoading }
-          noCopy
           truncation="constant"
+          noCopy
         />
       </ListItemMobileGrid.Value>
       <ListItemMobileGrid.Label isLoading={ isLoading }>From</ListItemMobileGrid.Label>
       <ListItemMobileGrid.Value>
-        <AddressEntityL1
-          address={{ hash: item.from, name: '', is_contract: false, is_verified: false, ens_domain_name: null, implementations: null }}
-          isLoading={ isLoading }
-          noCopy
-          truncation="constant"
-        />
+        <TwineExternalLink href={ item.from } chainId={ String(item.chain_id) } type="tx" isLoading={ isLoading }>
+          { shortenString(item.from, 8) }
+        </TwineExternalLink>
       </ListItemMobileGrid.Value>
       <ListItemMobileGrid.Label isLoading={ isLoading }>To (Twine Address)</ListItemMobileGrid.Label>
       <ListItemMobileGrid.Value>
@@ -94,7 +112,6 @@ const TwineWithdrawalsListItem = ({ item, isLoading }: Props) => {
       <ListItemMobileGrid.Value>
         { item.amount }
       </ListItemMobileGrid.Value>
-
     </ListItemMobileGrid.Container>
   );
 };

--- a/ui/withdrawals/twineL2/TwineL2WithdrawalsListItem.tsx
+++ b/ui/withdrawals/twineL2/TwineL2WithdrawalsListItem.tsx
@@ -79,22 +79,19 @@ const TwineWithdrawalsListItem = ({ item, isLoading }: Props) => {
 
       <ListItemMobileGrid.Label isLoading={ isLoading }>L1 Token Address</ListItemMobileGrid.Label>
       <ListItemMobileGrid.Value>
-        <TwineExternalLink href={ item.l1_token } chainId={ String(item.chain_id) } type="tx" isLoading={ isLoading }>
+        <TwineExternalLink href={ item.l1_token } chainId={ String(item.chain_id) } type="address" isLoading={ isLoading }>
           { shortenString(item.l1_token, 8) }
         </TwineExternalLink>
       </ListItemMobileGrid.Value>
       <ListItemMobileGrid.Label isLoading={ isLoading }>L2 Token Address</ListItemMobileGrid.Label>
       <ListItemMobileGrid.Value>
-        <AddressEntity
-          address={{ hash: item.l2_token, name: '', is_contract: false, is_verified: false, ens_domain_name: null, implementations: null }}
-          isLoading={ isLoading }
-          truncation="constant"
-          noCopy
-        />
+        <TwineExternalLink href={ item.l2_token } chainId={ String(item.chain_id) } type="address" isLoading={ isLoading }>
+          { shortenString(item.l2_token, 8) }
+        </TwineExternalLink>
       </ListItemMobileGrid.Value>
       <ListItemMobileGrid.Label isLoading={ isLoading }>From</ListItemMobileGrid.Label>
       <ListItemMobileGrid.Value>
-        <TwineExternalLink href={ item.from } chainId={ String(item.chain_id) } type="tx" isLoading={ isLoading }>
+        <TwineExternalLink href={ item.from } chainId={ String(item.chain_id) } type="address" isLoading={ isLoading }>
           { shortenString(item.from, 8) }
         </TwineExternalLink>
       </ListItemMobileGrid.Value>

--- a/ui/withdrawals/twineL2/TwineL2WithdrawalsTable.tsx
+++ b/ui/withdrawals/twineL2/TwineL2WithdrawalsTable.tsx
@@ -7,19 +7,22 @@ import { default as Thead } from 'ui/shared/TheadSticky';
 
 import TwineWithdrawalsTableItem from './TwineL2WithdrawalsTableItem';
 
- type Props = {
-   items: Array<TwineL2WithdrawalsItem>;
-   top: number;
-   isLoading?: boolean;
- };
+type Props = {
+  items: Array<TwineL2WithdrawalsItem>;
+  top: number;
+  isLoading?: boolean;
+};
 
-const TwineDepositsTable = ({ items, top, isLoading }: Props) => {
+const TwineWithdrawalsTable = ({ items, top, isLoading }: Props) => {
   return (
-    <Table style={{ tableLayout: 'auto' }} minW="950px">
+    <Table style={{ tableLayout: 'auto' }} minW="1100px">
       <Thead top={ top }>
         <Tr>
+          <Th>Chain</Th>
           <Th>Block No.</Th>
-          <Th>Txn hash</Th>
+          <Th>Slot No.</Th>
+          <Th>L1 Txn hash</Th>
+          <Th>L2 Txn hash</Th>
           <Th>Age</Th>
           <Th>L1 Token Address</Th>
           <Th>L2 Token Address</Th>
@@ -29,11 +32,11 @@ const TwineDepositsTable = ({ items, top, isLoading }: Props) => {
       </Thead>
       <Tbody>
         { items.map((item, index) => (
-          <TwineWithdrawalsTableItem key={ item.tx_hash + (isLoading ? index : '') } item={ item } isLoading={ isLoading }/>
+          <TwineWithdrawalsTableItem key={ item.l1_tx_hash + (isLoading ? index : '') } item={ item } isLoading={ isLoading }/>
         )) }
       </Tbody>
     </Table>
   );
 };
 
-export default TwineDepositsTable;
+export default TwineWithdrawalsTable;

--- a/ui/withdrawals/twineL2/TwineL2WithdrawalsTableItem.tsx
+++ b/ui/withdrawals/twineL2/TwineL2WithdrawalsTableItem.tsx
@@ -1,46 +1,60 @@
-import { Td, Tr } from '@chakra-ui/react';
+import { Td, Tr, Badge } from '@chakra-ui/react';
 import React from 'react';
 
 import type { TwineL2WithdrawalsItem } from 'types/api/twineL2';
 
 import config from 'configs/app';
+import { isTwineChainId, TWINE_CHAIN_MAPPING } from 'configs/app/features/twine';
+import shortenString from 'lib/shortenString';
 import AddressEntity from 'ui/shared/entities/address/AddressEntity';
-import AddressEntityL1 from 'ui/shared/entities/address/AddressEntityL1';
-import BlockEntityL1 from 'ui/shared/entities/block/BlockEntityL1';
-import TxEntity from 'ui/shared/entities/tx/TxEntity';
+import TwineExternalLink from 'ui/shared/links/TwineExternalLink';
 import TimeAgoWithTooltip from 'ui/shared/TimeAgoWithTooltip';
 
 const rollupFeature = config.features.rollup;
 
- type Props = { item: TwineL2WithdrawalsItem; isLoading?: boolean };
+type Props = { item: TwineL2WithdrawalsItem; isLoading?: boolean };
 
 const TwineWithdrawalsTableItem = ({ item, isLoading }: Props) => {
-
   if (!rollupFeature.isEnabled || rollupFeature.type !== 'twine') {
     return null;
   }
 
+  const isSolana = isTwineChainId(String(item.chain_id)) && item.chain_id === 900;
+  const chainKey = String(item.chain_id) as keyof typeof TWINE_CHAIN_MAPPING;
+  const chainName = TWINE_CHAIN_MAPPING[chainKey]?.name || String(item.chain_id);
+
   return (
     <Tr>
       <Td verticalAlign="middle">
-        <BlockEntityL1
-          number={ item.block_number }
-          isLoading={ isLoading }
-          fontSize="sm"
-          lineHeight={ 5 }
-          fontWeight={ 600 }
-          noIcon
-        />
+        <Badge colorScheme={ isSolana ? 'purple' : 'blue' }>{ chainName }</Badge>
       </Td>
       <Td verticalAlign="middle">
-        <TxEntity
-          isLoading={ isLoading }
-          hash={ item.tx_hash }
-          fontSize="sm"
-          lineHeight={ 5 }
-          truncation="constant_long"
-          noIcon
-        />
+        { !isSolana && item.block_number ? (
+          <TwineExternalLink href={ item.block_number } chainId={ String(item.chain_id) } type="block" isLoading={ isLoading }>
+            { item.block_number }
+          </TwineExternalLink>
+        ) : (
+          <span>-</span>
+        ) }
+      </Td>
+      <Td verticalAlign="middle">
+        { isSolana && item.slot_number ? (
+          <TwineExternalLink href={ item.slot_number } chainId={ String(item.chain_id) } type="slot" isLoading={ isLoading }>
+            { item.slot_number }
+          </TwineExternalLink>
+        ) : (
+          <span>-</span>
+        ) }
+      </Td>
+      <Td verticalAlign="middle">
+        <TwineExternalLink href={ item.l1_tx_hash } chainId={ String(item.chain_id) } type="tx" isLoading={ isLoading }>
+          { shortenString(item.l1_tx_hash, 8) }
+        </TwineExternalLink>
+      </Td>
+      <Td verticalAlign="middle">
+        <TwineExternalLink href={ item.l2_tx_hash } chainId={ String(item.chain_id) } type="tx" isLoading={ isLoading }>
+          { shortenString(item.l2_tx_hash, 8) }
+        </TwineExternalLink>
       </Td>
       <Td verticalAlign="middle" pr={ 12 }>
         <TimeAgoWithTooltip
@@ -50,14 +64,10 @@ const TwineWithdrawalsTableItem = ({ item, isLoading }: Props) => {
           display="inline-block"
         />
       </Td>
-
       <Td verticalAlign="middle">
-        <AddressEntityL1
-          address={{ hash: item.l1_token, name: '', is_contract: false, is_verified: false, ens_domain_name: null, implementations: null }}
-          isLoading={ isLoading }
-          truncation="constant"
-          noCopy
-        />
+        <TwineExternalLink href={ item.l1_token } chainId={ String(item.chain_id) } type="tx" isLoading={ isLoading }>
+          { shortenString(item.l1_token, 8) }
+        </TwineExternalLink>
       </Td>
       <Td verticalAlign="middle">
         <AddressEntity
@@ -68,12 +78,9 @@ const TwineWithdrawalsTableItem = ({ item, isLoading }: Props) => {
         />
       </Td>
       <Td verticalAlign="middle">
-        <AddressEntityL1
-          address={{ hash: item.from, name: '', is_contract: false, is_verified: false, ens_domain_name: null, implementations: null }}
-          isLoading={ isLoading }
-          truncation="constant"
-          noCopy
-        />
+        <TwineExternalLink href={ item.from } chainId={ String(item.chain_id) } type="tx" isLoading={ isLoading }>
+          { shortenString(item.from, 8) }
+        </TwineExternalLink>
       </Td>
       <Td verticalAlign="middle">
         <AddressEntity
@@ -83,7 +90,6 @@ const TwineWithdrawalsTableItem = ({ item, isLoading }: Props) => {
           noCopy
         />
       </Td>
-
     </Tr>
   );
 };


### PR DESCRIPTION
## Integrate Twine custom indexer endpoints in blockscout frontend

*[Integrates Twine L2-related data into the Blockscout frontend. Since Blockscout doesn’t natively support Twine, we built a custom indexer, proxied it through the Blockscout backend, and integrated it into the frontend to display Twine-specific data seamlessly.]*

### Checklist  

- [x] Deposit and Withdrawals pages are integrated (structural changes still expected).  
- [x] Batches page integration is pending.  
- [x] Integrate L1 status for block and transaction detail page
